### PR TITLE
Adds missing command argument to manual install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Then run these commands to apply:
     
 ```powershell
 spicetify config current_theme Hazy
-spicetify config inject_css 1 replace_colors 1 overwrite_assets 1
+spicetify config inject_css 1 replace_colors 1 overwrite_assets 1 inject_theme_js 1
 spicetify apply
 ```
 


### PR DESCRIPTION
The README manual installation guide is currently missing the inject_theme_js option, this should ensure people install the theme properly