### PR TITLE
Fix display issue in hazy options after reset button click

### DIFF
--- a/hazy.js
+++ b/hazy.js
@@ -652,10 +652,10 @@
         document.querySelector(".hazyOptionRow #satu-input").value = 70;
         document.querySelector(".hazyOptionRow #bright-input").value = 120;
 
-        document.querySelector(".hazyOptionRow #blur-value").textContent = "15px";
-        document.querySelector(".hazyOptionRow #cont-value").textContent = "50%";
-        document.querySelector(".hazyOptionRow #satu-value").textContent = "70%";
-        document.querySelector(".hazyOptionRow #bright-value").textContent = "120%";
+        document.querySelector(".hazyOptionRow #blur-value").textContent = "15";
+        document.querySelector(".hazyOptionRow #cont-value").textContent = "50";
+        document.querySelector(".hazyOptionRow #satu-value").textContent = "70";
+        document.querySelector(".hazyOptionRow #bright-value").textContent = "120";
 
 
         localStorage.setItem(value.getAttribute("blur_am"), 8);


### PR DESCRIPTION
![image](https://github.com/Astromations/Hazy/assets/124454788/28d9e0f7-51ba-4e8a-b363-a28e8d34e8b7)


> Modified JavaScript code to **remove redundant units (px and %)** from displayed values of blur, contrast, saturation, and brightness settings in the hazy options panel. This resolves the issue where values were erroneously appended with additional units (e.g., "15pxpx", "50%%") after clicking the reset button.