### PR TITLE
fix: marketplace icon alignment in libraryX

### DIFF
--- a/app.css
+++ b/app.css
@@ -1355,6 +1355,14 @@ EXPERIMENTAL FEATURES
 MARKETPLACE
 ---------*/
 
+a[aria-label="Marketplace"],
+a[href="/marketplace"]{
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  height: 40px;
+}
+
 .marketplace-grid .main-card-draggable {
   background-color: transparent !important;
   box-shadow: none !important;


### PR DESCRIPTION
fix for marketplace btn in libraryX

Current:
![image](https://github.com/Astromations/Hazy/assets/93819264/7557a59a-f28e-4f1d-9731-e1c3c9169c86)

Fixed:
![image](https://github.com/Astromations/Hazy/assets/93819264/4e5b6df0-3fda-41ce-9eaa-1a98984e8655)
