### PR TITLE
fix: marketplace header merged with global nav

### DIFF
--- a/app.css
+++ b/app.css
@@ -1426,10 +1426,12 @@ a[href="/marketplace"]{
   background-color: rgba(255,255,255,0.01);
 }
 
-.marketplace-header:has(.marketplace-header__left  .marketplace-sortBox-header) {
-  padding-bottom: 80px;
-  position: relative;
-  margin-top: -55px
+.marketplace-header {
+  position: static;
+}
+
+.Root.global-nav .marketplace-header {
+  padding-top: 4rem;
 }
 
 .marketplace-header {


### PR DESCRIPTION
fixed marketplace header merged with global nav and refactor the code for the non-global nav version

Issue: 
![image](https://github.com/Astromations/Hazy/assets/93819264/e1ecc93a-a8e2-4fb2-aac4-29f60c86cd9c)

Now :
![image](https://github.com/Astromations/Hazy/assets/93819264/ba4a7787-9a12-4685-8b77-fe7c55ff7a34)

Normal one (styles not modified refactored code): 
![image](https://github.com/Astromations/Hazy/assets/93819264/06181be3-ef98-4736-8006-a9f1e895b9d0)
