### PR TITLE
fix: Hotfix for issue #108

### DIFF
--- a/hazy.js
+++ b/hazy.js
@@ -44,14 +44,18 @@
   valueSet()
 
   async function fetchFadeTime() {
+    /* It seems that ._prefs isnt available anymore. Therefore the crossfade is being disabled for now.
     const response = await Spicetify.Platform.PlayerAPI._prefs.get({ key: "audio.crossfade_v2" });
     const crossfadeEnabled = response.entries["audio.crossfade_v2"].bool;
+    */
+   const crossfadeEnabled = false
     
     let FadeTime = "0.4s"; // Default value of 0.4 seconds, otherwise syncs with crossfade time
     
     if (crossfadeEnabled) {
-      const fadeTimeResponse = await Spicetify.Platform.PlayerAPI._prefs.get({ key: "audio.crossfade.time_v2" });
-      const fadeTime = fadeTimeResponse.entries["audio.crossfade.time_v2"].number;
+      /*const fadeTimeResponse = await Spicetify.Platform.PlayerAPI._prefs.get({ key: "audio.crossfade.time_v2" });
+      const fadeTime = fadeTimeResponse.entries["audio.crossfade.time_v2"].number;*/
+      const fadeTime = FadeTime
       const dividedTime = fadeTime / 1000;
       FadeTime = dividedTime + "s";
     }
@@ -158,19 +162,26 @@
   }
 
   function controlDimensions() {
+    
+    /*
+    ._prefs isn't available
     Spicetify.Platform.PlayerAPI._prefs.get({ key: 'app.browser.zoom-level' }).then((value) => {
       const  zoomLevel = value.entries['app.browser.zoom-level'].number;
       const zoomNum = Number(zoomLevel)
-      const multiplier = zoomNum != 0 ? zoomNum/50 : 0;
-      const isGlobalNav = document.querySelector(".Root__globalNav");
-      constant = 0.912872807
+    */
 
-        final_width = 135 * (constant**(multiplier));
-        final_height = (isGlobalNav ? 64 : 40) * (constant**(multiplier));
-        document.documentElement.style.setProperty("--control-width", Math.abs(final_width) + "px");
-        document.documentElement.style.setProperty("--control-height", Math.abs(final_height) + "px");
-        console.log("zoom adjusted")
-    });
+    // Using natives instead of Spicetify's API
+    const pixelRatio = window.devicePixelRatio || 1;
+    const multiplier = pixelRatio !== 1 ? pixelRatio / 1 : 0;
+    const isGlobalNav = document.querySelector(".Root__globalNav");
+    const constant = 0.912872807;
+
+    final_width = 135 * (constant**(multiplier));
+    final_height = (isGlobalNav ? 64 : 40) * (constant**(multiplier));
+    document.documentElement.style.setProperty("--control-width", Math.abs(final_width) + "px");
+    document.documentElement.style.setProperty("--control-height", Math.abs(final_height) + "px");
+    console.log("zoom adjusted")
+    //});
   }
   
   window.addEventListener('resize', function() {


### PR DESCRIPTION
**The issue is described in issue:** #108 

**Problem:**
._prefs isn't available anymore and is therefore returning "undefined".

**Solution:**
- "crossfadeEnabled" in the "fetchFadeTime" function has been set to false.
I haven't discovered a new way, to fetch the crossfade bool and timing, therefore false for now.
- "zoomLevel" in the "controlDimensions" function is now using a browser-native property ([devicePixelRatio](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio)) instead of Spicetify's API.
- Commented out every conflicting element that contains ._prefs for future referencing.

It should fix the problem Hazy is currently facing.