### PR TITLE
Use "Custom background" when current song's image_url is undefined

### DIFF
--- a/hazy.js
+++ b/hazy.js
@@ -95,7 +95,7 @@
     //custom code added by lily
     if (!config.useCustomColor) {
       let imageUrl;
-      if (!config.useCurrSongAsHome) {
+      if (!config.useCurrSongAsHome && Spicetify.Player.data.item.metadata.image_url) {
         imageUrl = Spicetify.Player.data.item.metadata.image_url.replace("spotify:image:", "https://i.scdn.co/image/");
       } else {
         const defImage = "https://i.imgur.com/Wl2D0h0.png";


### PR DESCRIPTION
When a song's `image_url` is undefined (when playing a local file) and the "Custom background" option is disabled, the background becomes black and there are errors in the console. This PR fixes this issue.
![image](https://github.com/user-attachments/assets/4565a389-fe52-47ab-8cc7-b3ecc64d2e19)
