### PR TITLE
fix: "clear recent search" button size

### DIFF
--- a/app.css
+++ b/app.css
@@ -804,6 +804,11 @@ SEARCH BAR
   background: none;
 }
 
+div#recent-searches-dropdown div[tabindex] > button {
+  height: 32px;
+  width: 172px;
+}
+
 /*-----------
 MISCELLANEOUS
 -----------*/


### PR DESCRIPTION
I have fixed the size of "clear recent search" 

Before:
![image](https://github.com/user-attachments/assets/9431dba9-cd7c-4a1d-b295-9460aa514b8d)

After:

![image](https://github.com/user-attachments/assets/2a67f86a-9b9e-477d-9bf6-d0e83606acd0)
