### PR TITLE
Fix: Gracefully handle fade time set if errored state

### DIFF
--- a/hazy.js
+++ b/hazy.js
@@ -105,25 +105,30 @@
   }
 
   async function fetchFadeTime() {
-    const response = await Spicetify.Platform.PlayerAPI._prefs.get({
-      key: "audio.crossfade_v2",
-    });
+    try {
+      const response = await Spicetify.Platform.PlayerAPI._prefs.get({
+        key: "audio.crossfade_v2",
+      });
 
-    // Default to 0.4s if crossfade is disabled
-    if (!response.entries["audio.crossfade_v2"].bool) {
-      document.documentElement.style.setProperty("--fade-time", "0.4s");
-      return;
+      // Default to 0.4s if crossfade is disabled
+      if (!response.entries["audio.crossfade_v2"].bool) {
+        document.documentElement.style.setProperty("--fade-time", "0.4s");
+        return;
+      }
+      const fadeTimeResponse = await Spicetify.Platform.PlayerAPI._prefs.get({
+        key: "audio.crossfade.time_v2",
+      });
+      const fadeTime = fadeTimeResponse.entries["audio.crossfade.time_v2"].number;
+  
+      // Use the CSS variable "--fade-time" for transition time
+      document.documentElement.style.setProperty(
+        "--fade-time",
+        `${fadeTime / 1000}s`
+      );
     }
-    const fadeTimeResponse = await Spicetify.Platform.PlayerAPI._prefs.get({
-      key: "audio.crossfade.time_v2",
-    });
-    const fadeTime = fadeTimeResponse.entries["audio.crossfade.time_v2"].number;
-
-    // Use the CSS variable "--fade-time" for transition time
-    document.documentElement.style.setProperty(
-      "--fade-time",
-      `${fadeTime / 1000}s`
-    );
+    catch (error) {
+      document.documentElement.style.setProperty("--fade-time", "0.4s");
+    }
   }
 
   function getCurrentBackground(replace) {


### PR DESCRIPTION
I noticed in the devtools console, the fetchFadeTime function would error out with `.get()` not existing on `Spicetify.Platform.PlayerAPI._prefs.get`.

In these cases, the exception would cause the function to exit before setting the fade time to the fallback value. This change causes it to set the fallback value if the function encounters an exception.