### PR TITLE
Improve invalid background handling

### DIFF
--- a/hazy.js
+++ b/hazy.js
@@ -133,9 +133,9 @@
 
   function getCurrentBackground(replace) {
     let url = Spicetify.Player.data.item.metadata.image_url;
-    if (toggles.UseCustomBackground || !url) return startImage;
     if (replace)
       url = url.replace("spotify:image:", "https://i.scdn.co/image/");
+    if (toggles.UseCustomBackground || !URL.canParse(url)) return startImage;
     return url;
   }
 


### PR DESCRIPTION
Added further checks to make sure invalid URLs aren't being set as backgrounds, which could be leading to the black backgrounds that sometimes appear upon startup.