### PR TITLE
fix getCurrentBackground

### DIFF
--- a/hazy.js
+++ b/hazy.js
@@ -133,9 +133,9 @@
 
   function getCurrentBackground(replace) {
     let url = Spicetify.Player.data.item.metadata.image_url;
+    if (toggles.UseCustomBackground || !URL.canParse(url)) return startImage;
     if (replace)
       url = url.replace("spotify:image:", "https://i.scdn.co/image/");
-    if (toggles.UseCustomBackground || !URL.canParse(url)) return startImage;
     return url;
   }
 


### PR DESCRIPTION
In commit https://github.com/Astromations/Hazy/commit/5769102179784f3544f13583677fb005ed26fc65, `getCurrentBackground` was modified.
The change results in a black background and an error when playing a local song.
![Screenshot_20250705_111553](https://github.com/user-attachments/assets/87d45d03-f879-4183-980b-740ff394658f)
This PR reverts that change.