### PR TITLE
Add no-cors mode to fetch request for image validation, fixes "Invalid Image" error

### DIFF
--- a/hazy.js
+++ b/hazy.js
@@ -674,7 +674,9 @@
       // Check if image background is valid
       let invalidImage = false;
       try {
-        await fetch(srcInput.value);
+        await fetch(srcInput.value, {
+          "mode": "no-cors"
+        });
       }
       catch (error) {
         invalidImage = true;


### PR DESCRIPTION
Fixes the CORS error with background images by setting `mode` to `no-cors` in the image validation fetch call.

#202 #203 #205 #210