### PR TITLE
fix: fix black bands on Windows window controls

### DIFF
--- a/app.css
+++ b/app.css
@@ -139,22 +139,9 @@ html:not(.spotify__container--is-desktop.fullscreen)
 }
 
 html:not(.spotify__container--is-desktop.fullscreen)
-  body.global-nav.windows:not(.video-full-window)::after {
-  --topbar-height: 64px;
-}
-
-html:not(.spotify__container--is-desktop.fullscreen)
   body.global-nav-centered.windows:not(.video-full-window)::after {
-  height: min(
-    32px / var(--zoom, 1),
-    var(--topbar-height, 64px) / var(--zoom, 1)
-  );
-  top: calc(
-    (
-        var(--topbar-height, 64px) / 1 -
-          min(32px / var(--zoom, 1), var(--topbar-height, 64px))
-      ) / 2
-  );
+  height: calc(var(--topbar-height, 64px) / var(--zoom, 1));
+  top: 0;
 }
 
 /* Hide empty window controls from DOM to fix spacing */


### PR DESCRIPTION
## Problem
On Windows, the minimize/maximize/close buttons display black bands above and below them, disrupting the theme aesthetics.

Fixes #211 #233 #242 #244

## Root Cause
The `::after` pseudo-element responsible for the window controls area was using an incorrect height calculation (`min(32px, topbar-height)`) with a complex `top: calc(...)` that didn't properly cover the full topbar height, leaving black bands visible.

## Fix
Simplified the height to cover the full topbar height and set `top: 0` to start from the very top of the window.

## Screenshots
### Before
<img width="696" height="70" alt="Capture d&#39;écran 2026-04-05 182414" src="https://github.com/user-attachments/assets/4da56cba-eb48-414d-8e62-427c65cb7e30" />


### After
<img width="491" height="60" alt="image" src="https://github.com/user-attachments/assets/3434236b-4fa2-4e38-8d81-558ec1d2e020" />

## Tested on
- Windows 11
- Spotify 1.2.86.502
- Spicetify 2.43.1