### PR TITLE
Fix "Add to playlist" context menu

### DIFF
--- a/app.css
+++ b/app.css
@@ -2498,9 +2498,9 @@ ul > div[data-tippy-root],
 /* Right click context menu (indented container) */
 .main-contextMenu-menuItem > div {
   backdrop-filter: blur(25px);
-  clip-path: inset(
-    0 round var(--button-border)
-  ); /* so the stupid blur filter doesn't go outside of the border radius */
+  /* so the stupid blur filter doesn't go outside of the border radius: */
+  /* EDIT 5/15/26: removed as it hid the 2nd-depth "Add to playlist" context menu */
+  /*clip-path: inset(0 round var(--button-border));*/
 }
 
 /* Right click context menu (item) */


### PR DESCRIPTION
I think it's more important for the menu to actually be visible than the blur filter being clipped

Original commit that added this line: https://github.com/Astromations/Hazy/commit/1963c786ce4805ae6ac08ae97fbc5ef02d7633c9#diff-2608daf50a1064a21cacd6377a059df9e035d3d459df72656af6e7f2070fb2c7R1983

Fixes #224 


If anyone wants it fixed before this is merged, here is the snippet CSS:
```css
.main-contextMenu-menuItem > div { clip-path: none !important }
```