### PR TITLE
Fix lyrics page breaking navigation

### DIFF
--- a/hazy.js
+++ b/hazy.js
@@ -377,12 +377,12 @@
           lyricsContentWrapper.style.width = "";
 
           // 0, 1 - blank lines
-          const lyric = document.querySelector(
+          const lyric = document.querySelectorAll(
             ".lyrics-lyricsContent-lyric"
           )[2];
           document.documentElement.style.setProperty(
             "--lyrics-text-direction",
-            /[\u0591-\u07FF]/.test(lyric.innerText) ? "right" : "left"
+            /[\u0591-\u07FF]/.test(lyric?.innerText ?? "") ? "right" : "left"
           );
 
           document.documentElement.style.setProperty(


### PR DESCRIPTION
Fixes #285

querySelector -> querySelectorAll. `[2]` on a single element is undefined, so `.innerText` threw inside the History.listen callback and cancelled every navigation while the lyrics page was open. Added a `?.` too for songs with less than 3 lines.
